### PR TITLE
Fix a CSS selector for database views

### DIFF
--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -448,7 +448,7 @@ class Parser:
                         f" row in table with block id {table_row_block_id}"
                     )
                 table_row_href = self.driver.find_element_by_css_selector(
-                    f"div[data-block-id='{table_row_block_id}'] > div > a"
+                    f"div[data-block-id='{table_row_block_id}'] > a"
                 ).get_attribute("href")
                 table_row_href = table_row_href.split("notion.so")[-1]
                 row_target_span = table_row.find("span")


### PR DESCRIPTION
I believe Notion has updated its database view, and as a result I was not able to select items inside a database with: `div[data-block-id='{table_row_block_id}'] > div > a`. This is the current database view (gallery view):

![image](https://user-images.githubusercontent.com/32114380/89728200-0f7f3f80-da5e-11ea-8103-7cbe6536f42f.png)

I changed the selector to `div[data-block-id='{table_row_block_id}'] > a` and was able to fetch the page successfully. I don't know if this change is for everyone so could you please double check this on your side?