### PR TITLE
Clean up encoded query params from file extension

### DIFF
--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -183,6 +183,8 @@ class Parser:
                             content_type = response.headers.get("content-type")
                             if content_type:
                                 file_extension = mimetypes.guess_extension(content_type)
+                        elif '%3f' in file_extension.lower():
+                            file_extension = re.split("%3f", file_extension, flags=re.IGNORECASE)[0]
                         destination = destination.with_suffix(file_extension)
 
                     Path(destination).parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
I recently created a web bookmark which linked to a YouTube playlist. The resolved URL was:

`https://www.notion.so/image/https%3A%2F%2Fi.ytimg.com%2Fvi%2F0A_G8C9C5Ww%2Fhqdefault.jpg%3Fsqp%3D-oaymwEWCKgBEF5IWvKriqkDCQgBFQAAiEIYAQ%3D%3D%26rs%3DAOn4CLDhHF0EJd3d_ZI5LK2ZGZJTwbJAVg%26days_since_epoch%3D18561?table=block&id=c8642773-8c54-4c2f-9a60-040251b85eda&width=500&userId=&cache=v2`

`%3F` is the URL encoded `?` character, so in the above URL, you can see how there were encoded query parameters in the image link passed to the `ytimg.com` URL. This led to problems viewing the image, because these encoded query parameters carried over into the file extension and thus the filename, but since the browser recognized the encodings, the image was never served properly.

To fix this, I made the script filter out any encoded query parameters that happen to be part of the file extension. This should be safe because file extensions generally only contain alphanumeric characters. `%3F` (and the lowercase version) would be unusual to see in a file extension.