### PR TITLE
Fix subpage links in tables

### DIFF
--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -464,7 +464,7 @@ class Parser:
                 table_row_href = "/" + table_row_block_id.replace("-", "")
                 row_target_span = table_row.find("span")
                 row_link_wrapper = soup.new_tag(
-                    "a", attrs={"href": table_row_href, "style": "cursor: pointer;"}
+                    "a", attrs={"href": table_row_href, "style": "cursor: pointer; color: inherit; text-decoration: none; fill: inherit;"}
                 )
                 row_target_span.wrap(row_link_wrapper)
 


### PR DESCRIPTION
This makes subpage links in tables not look like default HTML links.
Before:
![image](https://user-images.githubusercontent.com/52051107/99605183-da489d00-2a0f-11eb-96e7-ad58b2e9b940.png)
After:
![image](https://user-images.githubusercontent.com/52051107/99605809-20523080-2a11-11eb-9305-8091ef3b0206.png)
