### PR TITLE
Fix subpage links in tables for Safari

### DIFF
--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -463,6 +463,7 @@ class Parser:
                 table_row_block_id = table_row["data-block-id"]
                 table_row_href = "/" + table_row_block_id.replace("-", "")
                 row_target_span = table_row.find("span")
+                row_target_span["style"] = row_target_span["style"].replace("pointer-events: none;","")
                 row_link_wrapper = soup.new_tag(
                     "a", attrs={"href": table_row_href, "style": "cursor: pointer; color: inherit; text-decoration: none; fill: inherit;"}
                 )


### PR DESCRIPTION
The `pointer-events: none;` style tag will make the link unclickable by some browsers (tested on iOS and MacOS Safari). This pull request adds a line of code, which will delete this tag.