### PR TITLE
Support for Notion inline "alias" links

### DIFF
--- a/bundles/loconotion.css
+++ b/bundles/loconotion.css
@@ -34,6 +34,12 @@ div[role="button"]:not(.notion-record-icon):hover {
   padding-right: unset !important;
 }
 
+/* pull alias arrows back inline */
+svg.alias {
+  display: inline-block !important;
+  height: auto !important;
+}
+
 @media only screen and (max-width: 960px) {
   /* normalizes banner / page title width */
   .notion-scroller > div:not([class]),

--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -555,8 +555,10 @@ class Parser:
         # find sub-pages and clean slugs / links
         sub_pages = []
         for a in soup.findAll("a"):
-            if a["href"].startswith("/"):
+            sub_page_href = a["href"]
+            if sub_page_href.startswith("/"):
                 sub_page_href = "https://www.notion.so" + a["href"]
+            if sub_page_href.startswith("https://www.notion.so/"):
                 # if the link is an anchor link,
                 # check if the page hasn't already been parsed
                 if "#" in sub_page_href:


### PR DESCRIPTION
These use an SVG icon, and (for now, at least) sometimes have the full "https://www.notion.so" domain in the `href`.  Made a small CSS patch to deal with the SVG icon getting too much height by default, and updated the subpage detection to handle these `href` values.