### PR TITLE
Fix misplaced header on tables

### DIFF
--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -278,6 +278,12 @@ class Parser:
                 time.sleep(self.args["timeout"])
                 new_height = scroller.get_attribute("scrollHeight")
                 log.debug(f"New notion-scroller height after timeout is: {new_height}")
+                try:
+                    selector = '[style*="clip-path: polygon(0% -20%, 100% -20%, 100% 100%, 0% 100%)"]'
+                    self.driver.find_element_by_css_selector(selector)
+                    self.driver.execute_script("document.querySelector('" + selector + "').remove()")
+                except NoSuchElementException:
+                    pass
                 if new_height == last_height:
                     self.driver.execute_script("arguments[0].scrollTo(0, 0)", scroller)
                     break

--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -279,6 +279,7 @@ class Parser:
                 new_height = scroller.get_attribute("scrollHeight")
                 log.debug(f"New notion-scroller height after timeout is: {new_height}")
                 if new_height == last_height:
+                    self.driver.execute_script("arguments[0].scrollTo(0, 0)", scroller)
                     break
                 last_height = new_height
 


### PR DESCRIPTION
First off, huge fan of this project. Very grateful for its existence and everyone who contributed!
I'm rather new to contributing to public projects, so I'll take any feedback I get :)

I notice that the floating header can render in the middle of a scrolling table.
Consider this a "hotfix":
Scrolling to the top to make sure the headers are rendered in the right position and then remove the floating footer bar.
(I figured the header was more important) I thought this might work until we had a better solution

[Before](https://pankaja.dev/before/index)
[After](https://pankaja.dev/filimin-projects)