### PR TITLE
fix: persist font path changed stylesheet to file

### DIFF
--- a/loconotion/__init__.py
+++ b/loconotion/__init__.py
@@ -1,0 +1,1 @@
+import os, sys; sys.path.append(os.path.dirname(os.path.realpath(__file__)))

--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -420,7 +420,7 @@ class Parser:
                     continue
                 # css_file = link['href'].strip("/")
                 cached_css_file = self.cache_file("https://www.notion.so" + link["href"])
-                with open(self.dist_folder / cached_css_file, "rb") as f:
+                with open(self.dist_folder / cached_css_file, "rb+") as f:
                     stylesheet = cssutils.parseString(f.read())
                     # open the stylesheet and check for any font-face rule,
                     for rule in stylesheet.cssRules:
@@ -433,6 +433,10 @@ class Parser:
                                 f"https://www.notion.so/{font_file}"
                             )
                             rule.style["src"] = f"url({str(cached_font_file)})"
+                    f.seek(0)
+                    f.write(stylesheet.cssText)
+                    f.truncate()
+
                 link["href"] = str(cached_css_file)
 
         # add our custom logic to all toggle blocks

--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -545,12 +545,13 @@ class Parser:
         injects_custom_tags("body")
 
         # inject loconotion's custom stylesheet and script
-        loconotion_custom_css = self.cache_file(Path("bundles/loconotion.css"))
+
+        loconotion_custom_css = self.cache_file(Path(os.path.dirname(__file__)) / ".." / "bundles/loconotion.css")
         custom_css = soup.new_tag(
             "link", rel="stylesheet", href=str(loconotion_custom_css)
         )
         soup.head.insert(-1, custom_css)
-        loconotion_custom_js = self.cache_file(Path("bundles/loconotion.js"))
+        loconotion_custom_js = self.cache_file(Path(os.path.dirname(__file__)) / ".." / "bundles/loconotion.js")
         custom_script = soup.new_tag(
             "script", type="text/javascript", src=str(loconotion_custom_js)
         )


### PR DESCRIPTION
This fixes https://github.com/leoncvlt/loconotion/issues/26 .

Open the css file in `rb+` mode, and write the changed style sheet object.
