### PR TITLE
Add `inner_html` tag attribute to provide tag content

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,10 @@ theme = "dark"
 
   ## Custom Fonts ##
   # you can specify the name of a google font to use on the site - use the font embed name
-  # if in doubt select a style on fonts.google.com and navigate to the "embed" tag to 
+  # if in doubt select a style on fonts.google.com and navigate to the "embed" tag to
   # check the name under CSS rules
   # the following table keys controls the font of specific elements:
-  #   site: changes the font for the whole page (apart from code blocks) 
+  #   site: changes the font for the whole page (apart from code blocks)
   #         but the settings below override it
   #   navbar: site breadcrumbs on the top-left of the page
   #   title: page title (under the icon)
@@ -143,31 +143,38 @@ theme = "dark"
   code = ''
 
   ## Custom Element Injection ##
-  # defined as an array of tables [[site.inject]], followed by 'head' or 'body' to set 
+  # defined as an array of tables [[site.inject]], followed by 'head' or 'body' to set
   # the injection point, followed by name of the tag to inject
   # each key in the table maps to an atttribute in the tag
   # e.g. the following injects this tag in the <head>:
-  #   <link href="favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/> 
+  #   <link href="favicon-16x16.png" rel="icon" sizes="16x16" type="image/png"/>
   [[site.inject.head.link]]
-  rel="icon" 
+  rel="icon"
   sizes="16x16"
   type="image/png"
   href="/example/favicon-16x16.png"
-  
+
   # the following injects this tag in the in the <body>:
   #   <script src="custom-script.js" type="text/javascript"></script>
-  # note that all href / src files are copied to the root of the site folder 
+  # note that all href / src files are copied to the root of the site folder
   # regardless of their original path
   [[site.inject.body.script]]
   type="text/javascript"
   src="/example/custom-script.js"
 
+  # the following injects this script in the <head>:
+  #   <script>console.log("Hello, world!")</script>
+  [[site.inject.body.script]]
+  inner_html="""
+  console.log("Hello, world!")
+  """
+
 ## Individual Page Settings ##
-# the [pages] table defines override settings for individual pages, by defining 
+# the [pages] table defines override settings for individual pages, by defining
 # a sub-table named after the page url (or part of the url, but careful about
 # not using a string that appears in multiple page urls)
 [pages]
-  # the following settings will only apply to this page: 
+  # the following settings will only apply to this page:
   #   https://www.notion.so/d2fa06f244e64f66880bb0491f58223d
   [pages.d2fa06f244e64f66880bb0491f58223d]
     ## custom slugs ##
@@ -176,13 +183,13 @@ theme = "dark"
     slug = "games-list"
 
     # change the description meta tag for this page only
-    [[pages.d2fa06f244e64f66880bb0491f58223d.meta]] 
+    [[pages.d2fa06f244e64f66880bb0491f58223d.meta]]
     name = "description"
     content = "A fullscreen list database page, now with a pretty slug"
 
     # change the title font for this page only
     [pages.d2fa06f244e64f66880bb0491f58223d.fonts]
-    title = 'DM Mono' 
+    title = 'DM Mono'
 
   # set up pretty slugs and options for the other database pages
   [pages.54dab6011e604430a21dc477cb8e4e3a]

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ On top of this, the script can take these optional arguments:
 
 - [leonclvt.com](https://leoncvlt.com)
 - [aahnik.dev](https://aahnik.dev)
+- [flipio.ru](https://flipio.ru)
 
 If you used Loconotion to build a cool site and want it added to the list above, shoot me a mail or submit a pull request!
 

--- a/flipio_site.toml
+++ b/flipio_site.toml
@@ -47,4 +47,5 @@ page = "https://www.notion.so/b84e0a641e8949649ff431eb897306fc"
     slug = "prices"
   [pages.cb20e16176c94a47924785317673eb75]
     slug = "sitemap"
-
+  [pages.764097f8c03440e9b4f77567faeaea58]
+    slug = "locked-projects"

--- a/flipio_site.toml
+++ b/flipio_site.toml
@@ -1,0 +1,50 @@
+name = "flipio"
+
+# the notion.so page to being parsing from. This page will become the index.html
+# of the generated site, and loconotation will parse all sub-pages present on the page
+page = "https://www.notion.so/b84e0a641e8949649ff431eb897306fc"
+
+## Global Site Settings ##
+# this [site] table defines override settings for the whole site
+# later on we will see how to define settings for a single page
+[site]
+  ## Custom Meta Tags ##
+  # defined as an array of tables (double square brackets)
+  # each key in the table maps to an atttribute in the tag
+  # the following adds the tag <meta name="title" content="Loconotion Test Site"/>
+  [[site.meta]]
+  name = "title"
+  content = "Флипио. Квартиры, на которых вы заработаете."
+  [[site.meta]]
+  name = "description"
+  content = "Поиск квартир с дисконтом для ремонта и перепродажи."
+
+  [[site.inject.head.script]]
+  inner_html="""
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-N88MWVC');</script>
+  <!-- End Google Tag Manager -->
+  """
+
+[pages]
+  [pages.ca958dc1d2184df1b43207e44c010007]
+    slug = "filter"
+  [pages.a2aac2f50cd345db97125b9db0805c92]
+    slug = "contacts"
+  [pages.7a8cb4fd1afc49298815b14b9abcd85a]
+    slug = "signals"
+  [pages.b806e94595974387b0082a0eb20f0f7a]
+    slug = "analysis"
+  [pages.4c13d8dfd05f4eef8829d80a6a2654f5]
+    slug = "terms"
+  [pages.5e4108079ef441309b5f0543025ae871]
+    slug = "club"
+  [pages.abee1513f44f4fd39baffac017c14021]
+    slug = "prices"
+  [pages.cb20e16176c94a47924785317673eb75]
+    slug = "sitemap"
+

--- a/loconotion/__main__.py
+++ b/loconotion/__main__.py
@@ -127,7 +127,7 @@ def main():
                 log.critical(f"Connection error")
         else:
             if Path(args.target).is_file():
-                with open(args.target) as f:
+                with open(args.target, encoding="utf-8") as f:
                     parsed_config = toml.loads(f.read())
                     log.info(f"Initialising parser with configuration file")
                     log.debug(parsed_config)

--- a/loconotion/notionparser.py
+++ b/loconotion/notionparser.py
@@ -454,7 +454,7 @@ class Parser:
                     f.seek(0)
                     f.truncate()
                     f.write(stylesheet.cssText)
-                        
+
                 link["href"] = str(cached_css_file)
 
         # add our custom logic to all toggle blocks
@@ -546,6 +546,12 @@ class Parser:
                 for element in elements:
                     injected_tag = soup.new_tag(tag)
                     for attr, value in element.items():
+
+                        # `inner_html` refers to the tag's inner content
+                        # and will be added later
+                        if attr == "inner_html":
+                            continue
+
                         injected_tag[attr] = value
                         # if the value refers to a file, copy it to the dist folder
                         if attr.lower() == "href" or attr.lower() == "src":
@@ -557,6 +563,11 @@ class Parser:
                             # shutil.copyfile(source, destination)
                             injected_tag[attr] = str(cached_custom_file)  # source.name
                     log.debug(f"Injecting <{section}> tag: {str(injected_tag)}")
+
+                    # adding `inner_html` as the tag's content
+                    if "inner_html" in element:
+                        injected_tag.string = element["inner_html"]
+
                     soup.find(section).append(injected_tag)
 
         injects_custom_tags("head")
@@ -621,7 +632,7 @@ class Parser:
                             style['cursor'] = "default"
                             child['style'] = style.cssText
 
-            
+
         # exports the parsed page
         html_str = str(soup)
         html_file = self.get_page_slug(url) if url != index else "index.html"


### PR DESCRIPTION
If there's a `inner_html` attribute in a tag's injection settings, the contents of this attribute are inserted into the tag's inner HTML. See changes to README.md for an example.

This change was used by me to insert Google Tag Manager script which not only loads but also launches Google Tag Manager script.