### PR TITLE
Fixes the iOS extra image bottom padding issue

### DIFF
--- a/bundles/loconotion.js
+++ b/bundles/loconotion.js
@@ -94,5 +94,8 @@ const imgs = document.querySelectorAll("img:not(.notion-emoji)");
 
 for (let i = 0; i < imgs.length; i++) {
   parent = imgs[i].parentElement
-  parent.setAttribute("style", parent.getAttribute("style") + "; height:auto!important;");
+  let style = parent.getAttribute("style")
+  style = style.replace(/padding-bottom: 133\.333\%;/, "")
+  style = style + "; height:auto!important;"
+  parent.setAttribute("style",  style);
 }

--- a/bundles/loconotion.js
+++ b/bundles/loconotion.js
@@ -86,3 +86,12 @@ for (let i = 0; i < anchorLinks.length; i++) {
     });
   });
 }
+
+// fix the problem with images having an annoying extra padding
+// in Webkit renderers on iOS devices
+
+const imgs = document.getElementsByTagName("img");
+
+for (let i = 0; i < imgs.length; i++) {
+  imgs[i].parentElement.setAttribute("style", "height:auto!important;");
+}

--- a/bundles/loconotion.js
+++ b/bundles/loconotion.js
@@ -90,8 +90,9 @@ for (let i = 0; i < anchorLinks.length; i++) {
 // fix the problem with images having an annoying extra padding
 // in Webkit renderers on iOS devices
 
-const imgs = document.getElementsByTagName("img");
+const imgs = document.querySelectorAll("img:not(.notion-emoji)");
 
 for (let i = 0; i < imgs.length; i++) {
-  imgs[i].parentElement.setAttribute("style", "height:auto!important;");
+  parent = imgs[i].parentElement
+  parent.setAttribute("style", parent.getAttribute("style") + "; height:auto!important;");
 }


### PR DESCRIPTION
The website I created with loconotion used to have an annoying issue whereby the images had an extra bottom padding on iOS devices.
![photo_2021-05-18_18-53-13](https://user-images.githubusercontent.com/60138889/119086781-aece5b80-ba0e-11eb-86c0-10e0aea02200.jpg)
![photo_2021-05-20_13-55-19](https://user-images.githubusercontent.com/60138889/119086784-af66f200-ba0e-11eb-8696-b077c22dbcdf.jpg)
![photo_2021-05-20_13-55-12](https://user-images.githubusercontent.com/60138889/119086785-afff8880-ba0e-11eb-82cc-ff8e96959399.jpg)

This PR fixes this issue.
