### PR TITLE
Use specific Chrome version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,12 +4,12 @@ FROM python:3.8
 # We need wget to set up the PPA and xvfb to have a virtual screen and unzip to install the Chromedriver
 RUN apt-get update
 RUN apt-get install -y libgconf-2-4 wget xvfb unzip
-# Set up the Chrome PPA
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-RUN echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list
-# Update the package list and install chrome
-RUN apt-get update -y
-RUN apt-get install -y google-chrome-stable
+
+# Install Chrome (compatible version with chromedriver below)
+ARG CHROME_VERSION="87.0.4280.141-1"
+RUN wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${CHROME_VERSION}_amd64.deb \
+  && apt install -y /tmp/chrome.deb \
+  && rm /tmp/chrome.deb
 
 # RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
 # RUN dpkg -i google-chrome-stable_current_amd64.deb; apt-get -fy install


### PR DESCRIPTION
This PR forces the installation of Google Chrome 87.0.4280.141-1 on the Dockerfile.

This is needed because when running `docker-compose run loconotion <conf_file>` the following error was being thrown:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/app/loconotion/loconotion/__main__.py", line 144, in <module>
    main()
  File "/app/loconotion/loconotion/__main__.py", line 134, in main
    Parser(config=parsed_config, args=vars(args))
  File "/app/loconotion/loconotion/notionparser.py", line 84, in __init__
    self.driver = self.init_chromedriver()
  File "/app/loconotion/loconotion/notionparser.py", line 240, in init_chromedriver
    return webdriver.Chrome(
  File "/usr/local/lib/python3.8/site-packages/selenium/webdriver/chrome/webdriver.py", line 76, in __init__
    RemoteWebDriver.__init__(
  File "/usr/local/lib/python3.8/site-packages/selenium/webdriver/remote/webdriver.py", line 157, in __init__
    self.start_session(capabilities, browser_profile)
  File "/usr/local/lib/python3.8/site-packages/selenium/webdriver/remote/webdriver.py", line 252, in start_session
    response = self.execute(Command.NEW_SESSION, parameters)
  File "/usr/local/lib/python3.8/site-packages/selenium/webdriver/remote/webdriver.py", line 321, in execute
    self.error_handler.check_response(response)
  File "/usr/local/lib/python3.8/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
    raise exception_class(message, screen, stacktrace)
selenium.common.exceptions.SessionNotCreatedException: Message: session not created: This version of ChromeDriver only supports Chrome version 87
Current browser version is 91.0.4472.77 with binary path /usr/bin/google-chrome
```