### PR TITLE
Non-zero exit code on error

### DIFF
--- a/loconotion/__main__.py
+++ b/loconotion/__main__.py
@@ -3,6 +3,12 @@ import sys
 
 import modules.main as main
 
+def _exit():
+    try:
+        sys.exit(1)
+    except SystemExit:
+        os._exit(1)
+
 if __name__ == "__main__":
     try:
         args = main.get_args()
@@ -11,7 +17,10 @@ if __name__ == "__main__":
         parser.run()
     except KeyboardInterrupt:
         log.critical("Interrupted by user")
-        try:
-            sys.exit(0)
-        except SystemExit:
-            os._exit(0)
+        _exit()
+    except Exception as ex:
+        if args.verbose:
+            log.exception(ex)
+        else:
+            log.critical(f"{ex.__class__.__name__}: {str(ex)}")
+        _exit()

--- a/loconotion/modules/notionparser.py
+++ b/loconotion/modules/notionparser.py
@@ -26,7 +26,7 @@ try:
     cssutils.log.setLevel(logging.CRITICAL)  # removes warning logs from cssutils
 except ModuleNotFoundError as error:
     log.critical(f"ModuleNotFoundError: {error}. have your installed the requirements?")
-    sys.exit()
+    sys.exit(1)
 
 from .conditions import notion_page_loaded, toggle_block_has_opened
 
@@ -42,7 +42,7 @@ class Parser:
                 " make sure it contains a 'page' key with the url of the notion.site"
                 " page to parse"
             )
-            return
+            raise Exception()
 
         # get the site name from the config, or make it up by cleaning the target page's slug
         site_name = self.config.get("name", self.get_page_slug(index_url, extension=False))
@@ -222,7 +222,7 @@ class Parser:
                     " https://chromedriver.chromium.org/downloads and use the"
                     " --chromedriver argument to point to the chromedriver executable"
                 )
-                sys.exit()
+                raise exception
 
         log.info(f"Initialising chromedriver at {chromedriver_path}")
         logs_path = Path.cwd() / ".logs" / "webdrive.log"
@@ -259,12 +259,12 @@ class Parser:
 
         try:
             self.load_correct_theme(url)
-        except TimeoutException:
+        except TimeoutException as ex:
             log.critical(
                 "Timeout waiting for page content to load, or no content found."
                 " Are you sure the page is set to public?"
             )
-            return
+            raise ex
 
         self.scroll_to_the_bottom()
 


### PR DESCRIPTION
This changes all critical errors to raise exceptions. This allows to
have a single critical error handler that sets exit code to non-zero.

This way loconotion can be better used in automation jobs, where
loconotion failure should stop subsequent tasks.