### PR TITLE
Remove gallery header padding

### DIFF
--- a/bundles/loconotion.css
+++ b/bundles/loconotion.css
@@ -30,6 +30,7 @@ div[role="button"]:not(.notion-record-icon):hover {
 
 /* Resizes inlines databases */
 .notion-scroller .notion-collection_view-block > div,
+.notion-scroller .notion-collection_view-block > div > div > div,
 .notion-scroller .notion-collection_view-block .notion-list-view,
 .notion-scroller .notion-collection_view-block .notion-gallery-view,
 .notion-scroller .notion-collection_view-block .notion-table-view,


### PR DESCRIPTION
This makes the gallery headers to go back to their desired position.

Before:

<img width="915" alt="image" src="https://user-images.githubusercontent.com/422086/161039922-f44cdc24-4f5f-4471-a957-61c2efde4c27.png">

After:

<img width="730" alt="image" src="https://user-images.githubusercontent.com/422086/161039803-19e0a53d-2a69-4e1b-a194-92096bc9b511.png">

~I am sure this workaround was done for some legit reason which now might be reversed. We should start running some visual unit tests that would make it easy to know if when something breaks.~