### PR TITLE
Configurable extension in links

### DIFF
--- a/loconotion/modules/notionparser.py
+++ b/loconotion/modules/notionparser.py
@@ -683,10 +683,11 @@ class Parser:
                             )
                             continue
                     else:
+                        extension_in_links = self.config.get("extension_in_links", True)
                         a["href"] = (
-                            self.get_page_slug(sub_page_href)
+                            self.get_page_slug(sub_page_href, extension=extension_in_links)
                             if sub_page_href != self.index_url
-                            else "index.html"
+                            else ("index.html" if extension_in_links else "")
                         )
                     subpages.append(sub_page_href)
                     log.debug(f"Found link to page {a['href']}")


### PR DESCRIPTION
GitHub Pages resolves links without `.html` extension by automatically adding the extension back. This PR adds a configuration parameter that controls whether or not to add `.html` extension to the links in the page sources.

This results in neat and short slug support like an example here: https://nemunasring.lt/winter-season 