### PR TITLE
Fix: Pretty url /*.html → /

### DIFF
--- a/loconotion/modules/notionparser.py
+++ b/loconotion/modules/notionparser.py
@@ -695,6 +695,15 @@ class Parser:
         return subpages
 
     def export_parsed_page(self, url, soup):
+        # pretty url setting
+        # replace /*.html to /
+        for link in soup.findAll("a", rel="noopener noreferrer"):
+            if link.has_attr("href"):
+                tmp_href = f"/{link['href']}"
+                tmp_href = tmp_href.replace('.html', '')
+                # log.info(f"href: {tmp_href}")
+                link["href"] = tmp_href
+
         # exports the parsed page
         html_str = str(soup)
         html_file = self.get_page_slug(url) if url != self.index_url else "index.html"


### PR DESCRIPTION
## Problem
I have deployed my site via Netlify. However, the .html extension was attached to the URL and displayed to the user.
Enabling the PrettyURL option inside Netlify has the same problem.

## Update
Fix: Pretty url /*.html → /

`http://localhost:8080/ASDF.html` to `http://localhost:8080/ASDF`

Fixed the problem that netlify's pretty url was not applied

## Related issues
Pretty URLs instead of Ugly URLs https://github.com/leoncvlt/loconotion/issues/10