### PR TITLE
Feature: activate toggle on foldable titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ On top of this, the script can take these optional arguments:
 - [aahnik.dev](https://aahnik.dev)
 - [44px.ru](https://44px.ru)
 - [hotelpal.xyz](https://hotelpal.xyz)
+- [vincent-maladiere.github.io](https://vincent-maladiere.github.io/)
 
 If you used Loconotion to build a cool site and want it added to the list above, shoot me a mail or submit a pull request!
 


### PR DESCRIPTION
**Reference Issues/PRs**
Addresses #122

**What does this implement/fix?**
- Extend the toggle blocks selection to h1, h2, and h3 (namely `header`, `sub_header`, and `sub_sub_header`) via selenium to un-toggle them recursively.
- Extend the toggle blocks selection to the headers mentioned above via bs4 to set some custom loconotion ids.
- You can check the demo of this fix here: https://vincent-maladiere.github.io/4-statistics.html

**Other comments**
Hey, @leoncvlt thanks for this great work! I added my blog to the list of projects using loconotion but feel free to remove it :)