### PR TITLE
Strip aif production iframe

### DIFF
--- a/loconotion/modules/notionparser.py
+++ b/loconotion/modules/notionparser.py
@@ -380,6 +380,8 @@ class Parser:
         # remove scripts and other tags we don't want / need
         for unwanted in soup.findAll("script"):
             unwanted.decompose()
+        for aif_production in soup.findAll("iframe", {"src": "https://aif.notion.so/aif-production.html"}):
+            aif_production.decompose()
         for intercom_frame in soup.findAll("iframe", {"id": "intercom-frame"}):
             intercom_frame.decompose()
         for intercom_div in soup.findAll("div", {"class": "intercom-lightweight-app"}):


### PR DESCRIPTION
Strip aif-production iframe which has src="https://aif.notion.so/aif-production.html". Based on [Notion's Security and Privacy](https://www.notion.so/help/security-and-privacy), the iframe is tracking code as describe below
![image](https://user-images.githubusercontent.com/40964666/210111967-7cd92b50-cb0b-4d49-ba83-75312ab004ad.png)

I already run the tests script, but it already failed from the raw fork, but IMO my change didn't break the module. Below is the result.

Thanks for the easy-to-use module.
============================= test session starts =============================
platform win32 -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0 -- D:\Quantist\loconotion\env\Scripts\python.exe
cachedir: .pytest_cache
rootdir: D:\Quantist\loconotion
collecting ... collected 3 items

loconotion/tests/test_inject_custom_tags.py::test_inject_file FAILED     [ 33%]
loconotion/tests/test_inject_custom_tags.py::test_inject_url PASSED      [ 66%]
loconotion/tests/test_parser.py::test_parse_sample_page PASSED           [100%]

================================== FAILURES ===================================
______________________________ test_inject_file _______________________________

parser = <modules.notionparser.Parser object at 0x000001B5184F3B80>
soup = <MagicMock id='1877308744576'>

    def test_inject_file(parser: Parser, soup):
        custom_injects = {
            "body": {
                "script": [
                    {
                        "src": "loconotion/tests/test_file.txt"
                    }
                ]
            }
        }
        parser.inject_custom_tags("body", soup, custom_injects)
>       assert soup.new_tag.return_value.__setitem__.call_args == call("src", "c93ac3dbe4fa24abcb232ef9c63a633661226a3f.txt")
E       AssertionError: assert call('src', '...d4e85d22.txt') == call('src', '...61226a3f.txt')
E         Full diff:
E         - call('src', 'c93ac3dbe4fa24abcb232ef9c63a633661226a3f.txt')
E         + call('src', '9d0913514942b396e0a3d5cfda3296bcd4e85d22.txt')

loconotion\tests\test_inject_custom_tags.py:29: AssertionError
============================== warnings summary ===============================
loconotion/tests/test_inject_custom_tags.py::test_inject_url
  D:\Quantist\loconotion\env\lib\site-packages\urllib3\util\ssl_.py:259: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
    context = SSLContext(ssl_version or PROTOCOL_TLS)

loconotion/tests/test_inject_custom_tags.py::test_inject_url
  D:\Quantist\loconotion\env\lib\site-packages\urllib3\connection.py:406: DeprecationWarning: ssl.match_hostname() is deprecated
    match_hostname(cert, asserted_hostname)

loconotion/tests/test_parser.py: 83 warnings
  D:\Quantist\loconotion\env\lib\site-packages\cssutils\errorhandler.py:100: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    self._logcall(msg)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ===========================
FAILED loconotion/tests/test_inject_custom_tags.py::test_inject_file - Assert...
================== 1 failed, 2 passed, 85 warnings in 16.92s ==================
