### PR TITLE
Adds CLI argument to allow remaining downloads to continue after receiving a --timeout error

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,9 @@ On top of this, the script can take these optional arguments:
   --timeout TIMEOUT     Time in seconds to wait for the loading of lazy-loaded
                         dynamic elements (default 5). If content from the page
                         seems to be missing, try increasing this value
+  -C, --continue-after-timeout
+                        Continue to download remaining pages or elements after
+                        a --timeout error occurs
   --clean               Delete all previously cached files for the site before
                         generating it
   --clean-css           Delete previously cached .css files for the site

--- a/loconotion/modules/main.py
+++ b/loconotion/modules/main.py
@@ -51,6 +51,11 @@ def get_args():
         " If content from the page seems to be missing, try increasing this value",
     )
     argparser.add_argument(
+        "-C", "--continue-after-timeout",
+        action="store_true",
+        help="Continue to download remaining pages or elements after a --timeout error occurs",
+    )
+    argparser.add_argument(
         "--clean",
         action="store_true",
         help="Delete all previously cached files for the site before generating it",

--- a/loconotion/modules/notionparser.py
+++ b/loconotion/modules/notionparser.py
@@ -265,7 +265,13 @@ class Parser:
                 "Timeout waiting for page content to load, or no content found."
                 " Are you sure the page is set to public?"
             )
-            raise ex
+
+            if self.args.get("continue_after_timeout", True):
+                log.critical(
+                    "--continue-after-timeout is set, continuing to download remaining elements."
+                )
+            else:
+                raise ex
 
         # open the toggle blocks in the page
         self.open_toggle_blocks(self.args["timeout"])
@@ -360,7 +366,7 @@ class Parser:
         if len(new_toggle_blocks) > len(toggle_blocks):
             # if so, run the function again
             self.open_toggle_blocks(timeout, opened_toggles)
-        
+
     def _get_title_toggle_blocks(self):
         """Find toggle title blocks via their button element.
         """
@@ -375,7 +381,7 @@ class Parser:
                 if len(toggle_buttons) > 0:
                     title_toggle_blocks.append(block)
         return title_toggle_blocks
-    
+
     def clean_up(self, soup):
         # remove scripts and other tags we don't want / need
         for unwanted in soup.findAll("script"):
@@ -552,7 +558,7 @@ class Parser:
             for block in title_blocks:
                 if block.select_one("div[role=button]") is not None:
                     title_toggle_blocks.append(block)
-        return title_toggle_blocks 
+        return title_toggle_blocks
 
     def process_table_views(self, soup):
         # if there are any table views in the page, add links to the title rows


### PR DESCRIPTION
Adds a new command line arg (`-C` or `--continue-after-timeout`) that will let the download process continue after a timeout error is raised within `parse_page()`.

My use case:

> I have sub-pages under a published Notion page that I don't want to be visible to the whole world.
> I can "unpublish" those specific pages so Loconotion will skip them (it will time-out when trying to load them) and continue parsing all the remaining sub-pages.

It looks like my text editor also removed some trailing whitespace, I opted to leave those changes in this commit.